### PR TITLE
Add failsafe option to send notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ notify -h
     * --open (alias -o)
     * --port (alias -p)
     * --host
+    * --failsafe (alias -x; time in milliseconds)
 
 ## Example
 

--- a/bin.js
+++ b/bin.js
@@ -12,12 +12,13 @@ var aliases = {
   icon: 'i',
   sound: 's',
   open: 'o',
-  port: 'p'
+  port: 'p',
+  failsafe: 'x'
 };
 
 var argv = minimist(process.argv.slice(2), {
   alias: aliases,
-  string: [ 'icon', 'message', 'open', 'subtitle', 'title', 'host', 'port' ]
+  string: [ 'icon', 'message', 'open', 'subtitle', 'title', 'host', 'port', 'failsafe' ]
 });
 
 readme(aliases, [ 'host' ]);
@@ -46,6 +47,10 @@ if (process.stdin.isTTY) {
     }
     doNotification(passedOptions);
   });
+  if (typeof passedOptions.failsafe !== 'undefined') {
+    setTimeout(function() { doNotification(passedOptions) }, passedOptions.failsafe);
+    delete passedOptions.failsafe; // Do not pass failsafe to notifier
+  }
 }
 
 function doNotification(options) {
@@ -59,9 +64,7 @@ function doNotification(options) {
       console.error(err.message);
       process.exit(1);
     }
-
-    if (!msg) return;
-    console.log(msg);
+    if (msg) console.log(msg);
     process.exit(0);
   });
 }

--- a/bin.js
+++ b/bin.js
@@ -47,6 +47,7 @@ if (process.stdin.isTTY) {
     }
     doNotification(passedOptions);
   });
+
   if (typeof passedOptions.failsafe !== 'undefined') {
     setTimeout(function() { doNotification(passedOptions) }, passedOptions.failsafe);
     delete passedOptions.failsafe; // Do not pass failsafe to notifier
@@ -64,6 +65,7 @@ function doNotification(options) {
       console.error(err.message);
       process.exit(1);
     }
+
     if (msg) console.log(msg);
     process.exit(0);
   });


### PR DESCRIPTION
In some non-TTY environments – e.g. Webstorm/Intellij tasks – the streams never receive the 'data' or 'end' events, so notifications are not shown and the notifier process never ends.

This option will force the notification to send after `n` number of milliseconds.

I also changed the callback to always exit the process, not just when a message is returned from the notifier.

I tested on my Mac running macOS 10.11.6 (El Capitan).